### PR TITLE
use white boundary to calculate slider

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { expect, test } from '@playwright/test'
 import sliderCaptchaRecognizer from './src/index.js'
 
 const peakTestInterval = 1000

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@ceajs/slider-captcha",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ceajs/slider-captcha",
-      "version": "0.0.0",
+      "version": "0.0.1",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "opencv-wasm": "^4.3.0-10",
         "sharp": "^0.29.3"
       },
       "devDependencies": {
@@ -2240,11 +2240,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/opencv-wasm": {
-      "version": "4.3.0-10",
-      "resolved": "https://registry.npmjs.org/opencv-wasm/-/opencv-wasm-4.3.0-10.tgz",
-      "integrity": "sha512-EWmWLUzp2suoc6N44Y4ouWT85QwvShx23Q430R+lp6NyS828bjQn6mCgA3NJ6Z/S59aaTeeu+RhqPQIJIYld1w=="
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
@@ -4548,11 +4543,6 @@
         "is-docker": "^2.1.1",
         "is-wsl": "^2.2.0"
       }
-    },
-    "opencv-wasm": {
-      "version": "4.3.0-10",
-      "resolved": "https://registry.npmjs.org/opencv-wasm/-/opencv-wasm-4.3.0-10.tgz",
-      "integrity": "sha512-EWmWLUzp2suoc6N44Y4ouWT85QwvShx23Q430R+lp6NyS828bjQn6mCgA3NJ6Z/S59aaTeeu+RhqPQIJIYld1w=="
     },
     "path-is-absolute": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   "type": "module",
   "scripts": {
     "pub-test": "npm pack --json --dry-run",
-    "pub": "npm publish --access=public"
+    "pub": "npm publish --access=public",
+    "test": "playwright test",
+    "postinstall": "playwright install"
   },
   "repository": {
     "type": "git",
@@ -30,7 +32,6 @@
     "@playwright/test": "^1.17.1"
   },
   "dependencies": {
-    "opencv-wasm": "^4.3.0-10",
     "sharp": "^0.29.3"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,69 +1,104 @@
+import fs from 'fs'
+import sharp from 'sharp'
 
-import fs from 'fs';
-import sharp from 'sharp';
-
+// For counting test-case img index
 let globalN = 0
 const folder = 'processed-img'
-
-if (process.env.SAVE_IMG) {
-
-  if (!fs.existsSync(folder)) {
-    fs.mkdirSync(folder)
-  }
+if (!fs.existsSync(folder)) {
+  fs.mkdirSync(folder)
 }
 
 export default async function sliderCaptchaRecognizer(
-	bigImage,
-	smallImage,
-	n,
+  bigImage,
+  smallImage,
+  n
 ) {
-	const [bigImageBuffer, smallImageBuffer] = [bigImage, smallImage].map((image) => Buffer.from(image, 'base64'))
-	const [bigImageSharp, smallImageSharp] = [
-		sharp(bigImageBuffer).ensureAlpha(1),
-		sharp(smallImageBuffer),
-	]
+  const [bigImageBuffer, smallImageBuffer] = [
+    bigImage,
+    smallImage,
+  ].map((image) => Buffer.from(image, 'base64'))
+  const [bigImageSharp, smallImageSharp] = [
+    sharp(bigImageBuffer).ensureAlpha(1),
+    sharp(smallImageBuffer).ensureAlpha(1),
+  ]
 
-	const [{ data: bigImageData, info: bigImageMetaInfo }, { data: smallImageData, info: smallImageMetaInfo }] = [
-		await bigImageSharp.raw().toBuffer({ resolveWithObject: true }),
-		await smallImageSharp.raw().toBuffer({ resolveWithObject: true }),
-	]
+  const [
+    { data: bigImageData, info: bigImageMetaInfo },
+    { data: smallImageData, info: smallImageMetaInfo },
+  ] = [
+    await bigImageSharp
+      .raw()
+      .toBuffer({ resolveWithObject: true }),
+    await smallImageSharp
+      .raw()
+      .toBuffer({ resolveWithObject: true }),
+  ]
 
-	const sliderBoundaries = []
-	traverseArrayBuffer(smallImageData, smallImageMetaInfo, ([[x, y], [r, g, b]]) => {
-		if (r === 255 && g === 255 && b === 255) {
-			sliderBoundaries.push([x, y])
-		}
-	})
+  // Pure white (255, 255, 255) pixel's coordinates
+  const sliderBoundaries = []
+  traverseArrayBuffer(
+    smallImageData,
+    smallImageMetaInfo,
+    ([[x, y], [r, g, b]]) => {
+      if (r === 255 && g === 255 && b === 255) {
+        sliderBoundaries.push([x, y])
+      }
+    }
+  )
 
-	const results = []
-	for (let offset = 0; offset <= (bigImageMetaInfo.width - smallImageMetaInfo.width); offset++) {
-		const deltaWithWhite = sliderBoundaries.map(([x, y]) => {
-			const index = 4 * (y * bigImageMetaInfo.width + x + offset)
-			return [0, 1, 2].map((i) => (255 - bigImageData[index + i])).reduce((acc, cur) => acc + cur, 0)
-		}).reduce((acc, cur) => acc + cur, 0)
+  // Race match boudaries, accumulating differences, recording x-axis offset
+  let bestMatchResult = [Infinity, 0]
+  for (
+    let offset = 0;
+    offset <=
+    bigImageMetaInfo.width - smallImageMetaInfo.width;
+    offset++
+  ) {
+    const deltaWithWhite = sliderBoundaries
+      .map(([x, y]) => {
+        const index =
+          4 * (y * bigImageMetaInfo.width + x + offset)
+        return [0, 1, 2]
+          .map((i) => 255 - bigImageData[index + i])
+          .reduce((acc, cur) => acc + cur, 0)
+      })
+      .reduce((acc, cur) => acc + cur, 0)
+    if (deltaWithWhite < bestMatchResult[0]) {
+      bestMatchResult = [deltaWithWhite, offset]
+    }
+  }
 
-		results.push([deltaWithWhite, offset])
-	}
+  // The moving distance is determined by the left border of the slider
+  const movePercent =
+    bestMatchResult[1] / bigImageMetaInfo.width
 
-	const argMin = results.reduce((r, a) => (a[0] < r[0] ? a : r))[1]
-	const movePercent = argMin / bigImageMetaInfo.width
-
-	if (process.env.SAVE_IMG) {
-		sharp(bigImageData, { raw: bigImageMetaInfo }).composite([{
-			input: smallImageData,
-			top: 0,
-			left: argMin,
-			raw: smallImageMetaInfo,
-		}]).toFile(`${folder}/${n ?? (++globalN)}-combined.png`)
-	}
-	return movePercent
+  if (process.env.SAVE_IMG) {
+    sharp(bigImageData, { raw: bigImageMetaInfo })
+      .composite([
+        {
+          input: smallImageData,
+          top: 0,
+          left: argMin,
+          raw: smallImageMetaInfo,
+        },
+      ])
+      .toFile(`${folder}/${n ?? ++globalN}-combined.png`)
+  }
+  return movePercent
 }
 
-function traverseArrayBuffer(imageData, { width, height }, callback) {
-	for (let y = 0; y < height; y++) {
-		for (let x = 0; x < width; x++) {
-			const idx = 4 * (y * width + x)
-			callback([[x, y], [0, 1, 2, 3].map((i) => imageData[idx + i])])
-		}
-	}
+function traverseArrayBuffer(
+  imageData,
+  { width, height },
+  callback
+) {
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const idx = 4 * (y * width + x)
+      callback([
+        [x, y],
+        [0, 1, 2].map((i) => imageData[idx + i]),
+      ])
+    }
+  }
 }


### PR DESCRIPTION
在华侨大学的例子中，检测滑块通过白边速度更快，同时可以减少 "opencv" 的依赖
或者可以考虑作为 methods/WhiteBoundary 融入 repo